### PR TITLE
Add NBA probabilities subproject scaffolding

### DIFF
--- a/nba_probs/.gitignore
+++ b/nba_probs/.gitignore
@@ -1,0 +1,11 @@
+# Local Python caches
+__pycache__/
+*.py[cod]
+*.so
+
+# Virtual environments
+.venv/
+.env
+
+# Data artifacts
+/data/

--- a/nba_probs/README.md
+++ b/nba_probs/README.md
@@ -1,0 +1,37 @@
+# NBA Probabilities Toolkit
+
+This sub-project provides a structured path for building a tool that compares
+real-time NBA win probability estimates with Polymarket betting odds. The goal
+is to help you iterate from learning the basics of data collection all the way
+to creating a production-ready pipeline for spotting pricing discrepancies.
+
+The project is organized as a conventional Python package so that you can run
+experiments in notebooks while still having reusable, tested code. The
+accompanying documentation walks you through each milestone.
+
+## Repository layout
+
+```
+nba_probs/
+├── README.md                # High-level overview (this file)
+├── docs/                    # Step-by-step guides and research notes
+├── data/                    # Local storage for raw/interim data (ignored by git)
+├── notebooks/               # Jupyter notebooks for exploration and modeling
+├── pyproject.toml           # Python project configuration
+└── src/nba_probs/           # Reusable Python package code
+```
+
+## Getting started quickly
+
+1. **Create a virtual environment** (Python 3.10+ recommended) and install the
+   dependencies listed in `pyproject.toml`.
+2. **Follow `docs/STEP_BY_STEP.md`** for a guided walkthrough of the entire
+   workflow—from gathering play-by-play data to comparing it with Polymarket
+   odds.
+3. Keep exploration notebooks in the `notebooks/` directory and promote any
+   reusable code into `src/nba_probs/`.
+4. Use version control: commit frequently and document your progress in the
+   `docs/` directory as you explore data sources and refine your modeling
+   approach.
+
+Happy building!

--- a/nba_probs/docs/STEP_BY_STEP.md
+++ b/nba_probs/docs/STEP_BY_STEP.md
@@ -1,0 +1,110 @@
+# Step-by-step plan for building the NBA win-probability tracker
+
+This guide walks you from an empty project to a pipeline that compares your NBA
+win-probability model with real-time Polymarket odds. Treat it as a living
+checklist—update it as you learn more, make architectural decisions, and run
+experiments.
+
+## 0. Prerequisites
+
+- Install Python 3.10 or later.
+- Create and activate a virtual environment.
+- From the `nba_probs/` directory, install the package in editable mode:
+
+  ```bash
+  pip install -e .[notebooks]
+  ```
+
+- Configure a `.env` file (see `docs/environment.example`) with API keys when you
+  start integrating external services.
+
+## 1. Explore NBA play-by-play data
+
+1. Skim the [`nba_api`](https://github.com/swar/nba_api) documentation.
+2. Use the `PlayByPlayV3` endpoint to download a single game.
+3. Convert the event stream into one-minute buckets:
+   - Track the game clock and quarter to compute elapsed seconds.
+   - Keep running score by team.
+   - Record which team eventually won (target variable).
+4. Save the processed data to `data/raw/` as Parquet files (git-ignored).
+
+**Deliverable:** a notebook in `notebooks/01_download_single_game.ipynb`
+showing the pipeline for a single game, plus a helper function promoted to
+`src/nba_probs/data_pipeline.py` once it works.
+
+## 2. Automate historical data collection
+
+1. Build a catalog of game IDs for the 2023-2024 and 2024-2025 seasons using
+   `LeagueGameFinder` or schedule endpoints.
+2. Iterate over the game list, downloading play-by-play data and materializing
+   one-minute summaries to `data/processed/`.
+3. Include logging, retry handling, and rate-limit-friendly sleeps.
+
+**Deliverable:** a command-line script (e.g., `python -m nba_probs.cli.collect`)
+that populates your local dataset.
+
+> **Note:** The 2024-2025 NBA season schedule is not yet finalized. Until it is,
+> work with the latest completed season to develop and validate your pipeline.
+
+## 3. Baseline win-probability model
+
+1. Aggregate the minute-level summaries into a DataFrame with the following
+   columns:
+   - `game_id`
+   - `minute` (0 through 47)
+   - `score_margin` (home score minus away score)
+   - `seconds_remaining`
+   - `home_win` (binary target)
+2. Split into train/validation sets by season to avoid leakage.
+3. Train a logistic-regression model using scikit-learn.
+4. Evaluate calibration (Brier score, reliability plots) and overall accuracy.
+5. Save the trained model to `data/models/` using joblib.
+
+**Deliverable:** a notebook `notebooks/02_train_baseline_model.ipynb` and helper
+functions in `src/nba_probs/modeling.py`.
+
+## 4. Integrate Polymarket odds
+
+1. Read [Polymarket's API documentation](https://docs.polymarket.com/).
+2. Implement the client in `src/nba_probs/polymarket.py` to:
+   - List NBA moneyline markets.
+   - Fetch live orderbook data for a market.
+   - Convert prices to implied probabilities.
+3. Store snapshots in `data/polymarket/`.
+
+**Deliverable:** a script `python -m nba_probs.cli.polymarket_snapshot --game-id
+<id>` that records the latest market odds.
+
+## 5. Compare model vs. market
+
+1. Align timestamps between your in-game win-probability predictions and the
+   Polymarket snapshots.
+2. Compute metrics such as:
+   - Absolute probability difference.
+   - Z-score using model calibration error.
+   - Opportunity signals (e.g., threshold for actionable discrepancies).
+3. Visualize the time series of both probabilities for selected games.
+
+**Deliverable:** `notebooks/03_compare_model_vs_market.ipynb` demonstrating the
+comparison and surfacing the largest divergences.
+
+## 6. Towards real-time execution
+
+1. Set up a lightweight scheduler (e.g., APScheduler or cron) to call both data
+   sources during live games.
+2. Cache partial game state so you can update predictions incrementally.
+3. Implement alerting (Slack, email, console) when discrepancies exceed your
+   threshold.
+
+**Deliverable:** a prototype monitoring script in `src/nba_probs/monitoring.py`.
+
+## 7. Production hardening (future work)
+
+- Write automated tests for key transformations.
+- Add structured logging and observability.
+- Containerize the app for deployment (Docker).
+- Track model versions and data lineage (e.g., MLflow, DVC).
+
+Keep checking off items as you go. Update this guide with lessons learned and
+refinements to help future you (or collaborators) understand the project
+history.

--- a/nba_probs/docs/environment.example
+++ b/nba_probs/docs/environment.example
@@ -1,0 +1,10 @@
+# Copy this file to `.env` and fill in the secrets required for external services.
+# The project uses `python-dotenv` semantics (KEY=VALUE lines).
+
+# Optional: Polymarket API credentials (required for authenticated endpoints).
+POLYMARKET_API_KEY=
+POLYMARKET_API_SECRET=
+
+# Optional: HTTP proxy settings if you are behind a corporate firewall.
+HTTP_PROXY=
+HTTPS_PROXY=

--- a/nba_probs/pyproject.toml
+++ b/nba_probs/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "nba-probs"
+version = "0.1.0"
+description = "Tools for comparing NBA win probabilities with Polymarket odds"
+readme = "README.md"
+authors = [
+  { name = "Your Name" }
+]
+requires-python = ">=3.10"
+dependencies = [
+  "numpy>=1.24",
+  "pandas>=2.1",
+  "scikit-learn>=1.3",
+  "nba_api>=1.4.1",
+  "pydantic>=2.0",
+  "pydantic-settings>=2.0",
+  "requests>=2.31",
+  "joblib>=1.3",
+  "pyarrow>=14.0",
+  "tqdm>=4.66"
+]
+
+[project.optional-dependencies]
+notebooks = [
+  "jupyterlab>=4.0",
+  "ipykernel>=6.25",
+  "matplotlib>=3.8",
+  "seaborn>=0.13"
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/nba_probs/src/nba_probs/__init__.py
+++ b/nba_probs/src/nba_probs/__init__.py
@@ -1,5 +1,3 @@
 """Core package for the NBA probabilities project."""
 
-from .config import Settings
-
-__all__ = ["Settings"]
+__all__ = []

--- a/nba_probs/src/nba_probs/__init__.py
+++ b/nba_probs/src/nba_probs/__init__.py
@@ -1,0 +1,5 @@
+"""Core package for the NBA probabilities project."""
+
+from .config import Settings
+
+__all__ = ["Settings"]

--- a/nba_probs/src/nba_probs/cli/__init__.py
+++ b/nba_probs/src/nba_probs/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line entry points for the nba_probs project."""

--- a/nba_probs/src/nba_probs/cli/collect.py
+++ b/nba_probs/src/nba_probs/cli/collect.py
@@ -1,0 +1,50 @@
+"""CLI for downloading historical NBA play-by-play data."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from ..config import get_settings
+from ..data_pipeline import batch_fetch
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Download NBA games and summarize by minute")
+    parser.add_argument("game_ids", nargs="+", help="NBA game IDs to download")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to save the concatenated dataset (Parquet format)",
+    )
+    parser.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Disable tqdm progress bar",
+    )
+    return parser.parse_args()
+
+
+def main(args: argparse.Namespace | None = None) -> None:
+    if args is None:
+        args = parse_args()
+
+    settings = get_settings()
+    dataset = batch_fetch(args.game_ids, show_progress=not args.no_progress)
+
+    if args.output is not None:
+        output_path = args.output
+    else:
+        output_path = settings.paths.processed_data_dir / "minutes.parquet"
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    dataset.to_parquet(output_path, index=False)
+    print(f"Saved {len(dataset)} rows to {output_path}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/nba_probs/src/nba_probs/cli/polymarket_snapshot.py
+++ b/nba_probs/src/nba_probs/cli/polymarket_snapshot.py
@@ -1,0 +1,56 @@
+"""CLI for capturing Polymarket orderbook snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ..config import get_settings
+from ..polymarket import PolymarketClient
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Capture a Polymarket orderbook snapshot")
+    parser.add_argument("market_id", help="Polymarket market identifier")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional JSON file to append snapshot data",
+    )
+    return parser.parse_args()
+
+
+def main(args: argparse.Namespace | None = None) -> None:
+    if args is None:
+        args = parse_args()
+
+    settings = get_settings()
+    client = PolymarketClient()
+    snapshot = client.fetch_orderbook(args.market_id)
+
+    payload = {
+        "market_id": snapshot.market_id,
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        "yes_price": snapshot.yes_price,
+        "no_price": snapshot.no_price,
+        "implied_yes_probability": snapshot.implied_yes_probability,
+        "implied_no_probability": snapshot.implied_no_probability,
+    }
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        existing = []
+        if args.output.exists():
+            existing = json.loads(args.output.read_text())
+        existing.append(payload)
+        args.output.write_text(json.dumps(existing, indent=2))
+        print(f"Snapshot appended to {args.output}")
+    else:
+        print(json.dumps(payload, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/nba_probs/src/nba_probs/config.py
+++ b/nba_probs/src/nba_probs/config.py
@@ -1,0 +1,56 @@
+"""Configuration management for the NBA probability project."""
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Paths(BaseModel):
+    """Collection of commonly used project paths."""
+
+    project_root: Path = Field(default_factory=lambda: Path(__file__).resolve().parents[2])
+    data_dir: Path = Field(default_factory=lambda: Path(__file__).resolve().parents[2] / "data")
+    raw_data_dir: Path = Field(default_factory=lambda: Path(__file__).resolve().parents[2] / "data" / "raw")
+    processed_data_dir: Path = Field(default_factory=lambda: Path(__file__).resolve().parents[2] / "data" / "processed")
+    models_dir: Path = Field(default_factory=lambda: Path(__file__).resolve().parents[2] / "data" / "models")
+    polymarket_dir: Path = Field(default_factory=lambda: Path(__file__).resolve().parents[2] / "data" / "polymarket")
+
+    def ensure_exists(self) -> None:
+        """Create directories if they do not already exist."""
+
+        for path in {
+            self.data_dir,
+            self.raw_data_dir,
+            self.processed_data_dir,
+            self.models_dir,
+            self.polymarket_dir,
+        }:
+            path.mkdir(parents=True, exist_ok=True)
+
+
+class Settings(BaseSettings):
+    """Runtime configuration derived from environment variables."""
+
+    polymarket_api_key: Optional[str] = Field(default=None, alias="POLYMARKET_API_KEY")
+    polymarket_api_secret: Optional[str] = Field(default=None, alias="POLYMARKET_API_SECRET")
+    http_proxy: Optional[str] = Field(default=None, alias="HTTP_PROXY")
+    https_proxy: Optional[str] = Field(default=None, alias="HTTPS_PROXY")
+
+    paths: Paths = Field(default_factory=Paths)
+
+    model_config = SettingsConfigDict(env_file=Path(__file__).resolve().parents[2] / ".env", extra="ignore")
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return a cached Settings instance."""
+
+    settings = Settings()  # type: ignore[call-arg]
+    settings.paths.ensure_exists()
+    return settings
+
+
+__all__ = ["Settings", "Paths", "get_settings"]

--- a/nba_probs/src/nba_probs/data_pipeline.py
+++ b/nba_probs/src/nba_probs/data_pipeline.py
@@ -1,0 +1,128 @@
+"""Utilities for collecting and transforming NBA game data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, List, Optional
+
+import pandas as pd
+from nba_api.stats.endpoints import playbyplayv3
+from tqdm import tqdm
+
+from .config import get_settings
+
+
+@dataclass
+class GameMinute:
+    """Representation of a single minute of game play."""
+
+    game_id: str
+    minute_index: int
+    period: int
+    seconds_remaining: int
+    home_team_score: int
+    away_team_score: int
+    home_team_id: int
+    away_team_id: int
+    home_win: Optional[int]
+    game_date: Optional[datetime]
+
+    @property
+    def score_margin(self) -> int:
+        return self.home_team_score - self.away_team_score
+
+
+def fetch_play_by_play(game_id: str) -> pd.DataFrame:
+    """Fetch raw play-by-play data for a given NBA game ID."""
+
+    settings = get_settings()
+    headers = {}
+    if settings.polymarket_api_key:  # not needed but placeholder for proxies
+        headers["X-API-Key"] = settings.polymarket_api_key
+
+    response = playbyplayv3.PlayByPlayV3(game_id=game_id, headers=headers)
+    data = response.get_normalized_dict()
+    plays = pd.DataFrame(data["playByPlay"])
+    plays["gameId"] = game_id
+    return plays
+
+
+def summarize_game_by_minute(plays: pd.DataFrame) -> pd.DataFrame:
+    """Convert raw play-by-play events into one-minute summaries."""
+
+    if plays.empty:
+        raise ValueError("Expected play-by-play events, received empty DataFrame")
+
+    plays = plays.copy()
+    plays["periodNumber"] = plays["periodNumber"].astype(int)
+    plays["clock"] = pd.to_timedelta(plays["clock"])
+
+    periods = plays.groupby("periodNumber")
+
+    minutes: List[GameMinute] = []
+
+    for period, group in periods:
+        group = group.sort_values("clock", ascending=False)
+        game_clock = 12 * 60 if period <= 4 else 5 * 60
+
+        home_score = 0
+        away_score = 0
+
+        for _, row in group.iterrows():
+            home_score = int(row["homeScore"])
+            away_score = int(row["awayScore"])
+            elapsed = game_clock - int(row["clock"].total_seconds())
+            minute_index = elapsed // 60
+
+            minute = GameMinute(
+                game_id=row["gameId"],
+                minute_index=int(minute_index + (period - 1) * 12),
+                period=int(period),
+                seconds_remaining=int(row["clock"].total_seconds() + (4 - period) * 12 * 60 if period <= 4 else row["clock"].total_seconds()),
+                home_team_score=home_score,
+                away_team_score=away_score,
+                home_team_id=int(row["homeTeamId"]),
+                away_team_id=int(row["visitorTeamId"]),
+                home_win=None,
+                game_date=pd.to_datetime(row.get("gameDate")) if "gameDate" in row else None,
+            )
+            minutes.append(minute)
+
+    df = pd.DataFrame([m.__dict__ for m in minutes]).drop_duplicates(subset=["game_id", "minute_index"], keep="last")
+
+    last_row = plays.iloc[-1]
+    home_win = int(last_row["homeScore"] > last_row["awayScore"])
+    df["home_win"] = home_win
+    df["score_margin"] = df["home_team_score"] - df["away_team_score"]
+    df.sort_values("minute_index", inplace=True)
+    return df
+
+
+def batch_fetch(game_ids: Iterable[str], show_progress: bool = True) -> pd.DataFrame:
+    """Download and summarize multiple games."""
+
+    records: List[pd.DataFrame] = []
+    iterator: Iterable[str] = tqdm(game_ids, desc="Downloading games") if show_progress else game_ids
+
+    for game_id in iterator:
+        try:
+            plays = fetch_play_by_play(game_id)
+            minutes = summarize_game_by_minute(plays)
+            records.append(minutes)
+        except Exception as exc:  # pragma: no cover - debug logging placeholder
+            print(f"Failed to process game {game_id}: {exc}")
+            continue
+
+    if not records:
+        raise RuntimeError("No games were successfully processed.")
+
+    return pd.concat(records, ignore_index=True)
+
+
+__all__ = [
+    "GameMinute",
+    "fetch_play_by_play",
+    "summarize_game_by_minute",
+    "batch_fetch",
+]

--- a/nba_probs/src/nba_probs/data_pipeline.py
+++ b/nba_probs/src/nba_probs/data_pipeline.py
@@ -6,10 +6,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Iterable, List, Optional
 
-import pandas as pd
-from nba_api.stats.endpoints import playbyplayv3
-from tqdm import tqdm
-
 from .config import get_settings
 
 
@@ -33,8 +29,11 @@ class GameMinute:
         return self.home_team_score - self.away_team_score
 
 
-def fetch_play_by_play(game_id: str) -> pd.DataFrame:
+def fetch_play_by_play(game_id: str):
     """Fetch raw play-by-play data for a given NBA game ID."""
+
+    from nba_api.stats.endpoints import playbyplayv3  # type: ignore import-not-found
+    import pandas as pd  # type: ignore import-not-found
 
     settings = get_settings()
     headers = {}
@@ -48,8 +47,10 @@ def fetch_play_by_play(game_id: str) -> pd.DataFrame:
     return plays
 
 
-def summarize_game_by_minute(plays: pd.DataFrame) -> pd.DataFrame:
+def summarize_game_by_minute(plays):
     """Convert raw play-by-play events into one-minute summaries."""
+
+    import pandas as pd  # type: ignore import-not-found
 
     if plays.empty:
         raise ValueError("Expected play-by-play events, received empty DataFrame")
@@ -99,8 +100,12 @@ def summarize_game_by_minute(plays: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def batch_fetch(game_ids: Iterable[str], show_progress: bool = True) -> pd.DataFrame:
+def batch_fetch(game_ids: Iterable[str], show_progress: bool = True):
     """Download and summarize multiple games."""
+
+    import pandas as pd  # type: ignore import-not-found
+
+    from tqdm import tqdm  # type: ignore import-not-found
 
     records: List[pd.DataFrame] = []
     iterator: Iterable[str] = tqdm(game_ids, desc="Downloading games") if show_progress else game_ids

--- a/nba_probs/src/nba_probs/modeling.py
+++ b/nba_probs/src/nba_probs/modeling.py
@@ -1,0 +1,119 @@
+"""Model training and inference utilities for win probability estimation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Tuple
+
+import joblib
+import numpy as np
+import pandas as pd
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import brier_score_loss, roc_auc_score
+from sklearn.model_selection import train_test_split
+
+from .config import get_settings
+
+
+@dataclass
+class ModelArtifacts:
+    """Container for artifacts produced during training."""
+
+    model: LogisticRegression
+    features: Tuple[str, ...]
+    brier: float
+    roc_auc: float
+    train_rows: int
+    test_rows: int
+
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        joblib.dump({
+            "model": self.model,
+            "features": self.features,
+            "brier": self.brier,
+            "roc_auc": self.roc_auc,
+            "train_rows": self.train_rows,
+            "test_rows": self.test_rows,
+        }, path)
+
+
+FEATURES = ("score_margin", "seconds_remaining")
+TARGET = "home_win"
+
+
+def train_baseline_model(data: pd.DataFrame, *, random_state: int = 42) -> ModelArtifacts:
+    """Train a baseline logistic regression model on the provided dataset."""
+
+    missing_columns = {col for col in (*FEATURES, TARGET) if col not in data.columns}
+    if missing_columns:
+        raise ValueError(f"Missing required columns: {missing_columns}")
+
+    df = data.dropna(subset=[*FEATURES, TARGET])
+    if df.empty:
+        raise ValueError("No rows available for training after dropping missing values.")
+
+    X = df.loc[:, FEATURES]
+    y = df.loc[:, TARGET]
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=random_state, stratify=y
+    )
+
+    model = LogisticRegression(max_iter=1000)
+    model.fit(X_train, y_train)
+
+    prob_test = model.predict_proba(X_test)[:, 1]
+    brier = brier_score_loss(y_test, prob_test)
+    roc_auc = roc_auc_score(y_test, prob_test)
+
+    return ModelArtifacts(
+        model=model,
+        features=FEATURES,
+        brier=brier,
+        roc_auc=roc_auc,
+        train_rows=len(X_train),
+        test_rows=len(X_test),
+    )
+
+
+def predict_win_probability(model: LogisticRegression, *, score_margin: float, seconds_remaining: float) -> float:
+    """Return the probability of the home team winning."""
+
+    X = np.array([[score_margin, seconds_remaining]])
+    return float(model.predict_proba(X)[0, 1])
+
+
+def save_model(artifacts: ModelArtifacts, filename: str = "baseline_model.joblib") -> Path:
+    """Persist trained model artifacts to disk."""
+
+    settings = get_settings()
+    path = settings.paths.models_dir / filename
+    artifacts.save(path)
+    return path
+
+
+def load_model(path: Path | None = None) -> ModelArtifacts:
+    """Load model artifacts from disk."""
+
+    settings = get_settings()
+    target_path = path or (settings.paths.models_dir / "baseline_model.joblib")
+    payload = joblib.load(target_path)
+    return ModelArtifacts(
+        model=payload["model"],
+        features=tuple(payload["features"]),
+        brier=float(payload["brier"]),
+        roc_auc=float(payload["roc_auc"]),
+        train_rows=int(payload["train_rows"]),
+        test_rows=int(payload["test_rows"]),
+    )
+
+
+__all__ = [
+    "ModelArtifacts",
+    "train_baseline_model",
+    "predict_win_probability",
+    "save_model",
+    "load_model",
+]

--- a/nba_probs/src/nba_probs/modeling.py
+++ b/nba_probs/src/nba_probs/modeling.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Tuple
+from typing import Tuple, TYPE_CHECKING
 
-import joblib
-import numpy as np
-import pandas as pd
-from sklearn.linear_model import LogisticRegression
-from sklearn.metrics import brier_score_loss, roc_auc_score
-from sklearn.model_selection import train_test_split
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    import joblib  # type: ignore import-not-found
+    import numpy as np  # type: ignore import-not-found
+    import pandas as pd  # type: ignore import-not-found
+    from sklearn.linear_model import LogisticRegression  # type: ignore import-not-found
 
 from .config import get_settings
 
@@ -28,6 +27,8 @@ class ModelArtifacts:
     test_rows: int
 
     def save(self, path: Path) -> None:
+        import joblib  # type: ignore import-not-found
+
         path.parent.mkdir(parents=True, exist_ok=True)
         joblib.dump({
             "model": self.model,
@@ -45,6 +46,12 @@ TARGET = "home_win"
 
 def train_baseline_model(data: pd.DataFrame, *, random_state: int = 42) -> ModelArtifacts:
     """Train a baseline logistic regression model on the provided dataset."""
+
+    import numpy as np  # type: ignore import-not-found
+    import pandas as pd  # type: ignore import-not-found
+    from sklearn.linear_model import LogisticRegression  # type: ignore import-not-found
+    from sklearn.metrics import brier_score_loss, roc_auc_score  # type: ignore import-not-found
+    from sklearn.model_selection import train_test_split  # type: ignore import-not-found
 
     missing_columns = {col for col in (*FEATURES, TARGET) if col not in data.columns}
     if missing_columns:
@@ -81,6 +88,8 @@ def train_baseline_model(data: pd.DataFrame, *, random_state: int = 42) -> Model
 def predict_win_probability(model: LogisticRegression, *, score_margin: float, seconds_remaining: float) -> float:
     """Return the probability of the home team winning."""
 
+    import numpy as np  # type: ignore import-not-found
+
     X = np.array([[score_margin, seconds_remaining]])
     return float(model.predict_proba(X)[0, 1])
 
@@ -96,6 +105,8 @@ def save_model(artifacts: ModelArtifacts, filename: str = "baseline_model.joblib
 
 def load_model(path: Path | None = None) -> ModelArtifacts:
     """Load model artifacts from disk."""
+
+    import joblib  # type: ignore import-not-found
 
     settings = get_settings()
     target_path = path or (settings.paths.models_dir / "baseline_model.joblib")

--- a/nba_probs/src/nba_probs/polymarket.py
+++ b/nba_probs/src/nba_probs/polymarket.py
@@ -1,0 +1,96 @@
+"""Lightweight client for interacting with the Polymarket API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+
+import requests
+
+from .config import get_settings
+
+POLYMARKET_BASE_URL = "https://gamma-api.polymarket.com"
+
+
+@dataclass
+class Market:
+    """Simplified representation of a Polymarket market."""
+
+    id: str
+    question: str
+    status: str
+    outcome_yes: Optional[str]
+    outcome_no: Optional[str]
+
+
+@dataclass
+class Orderbook:
+    """Orderbook snapshot for a binary Polymarket market."""
+
+    market_id: str
+    yes_price: Optional[float]
+    no_price: Optional[float]
+
+    @property
+    def implied_yes_probability(self) -> Optional[float]:
+        if self.yes_price is None:
+            return None
+        return self.yes_price
+
+    @property
+    def implied_no_probability(self) -> Optional[float]:
+        if self.no_price is None:
+            return None
+        return self.no_price
+
+
+class PolymarketClient:
+    """Simple wrapper around Polymarket's HTTP API."""
+
+    def __init__(self) -> None:
+        self.settings = get_settings()
+        self.session = requests.Session()
+        if self.settings.http_proxy:
+            self.session.proxies["http"] = self.settings.http_proxy
+        if self.settings.https_proxy:
+            self.session.proxies["https"] = self.settings.https_proxy
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> Any:
+        url = f"{POLYMARKET_BASE_URL}{path}"
+        response = self.session.request(method, url, timeout=10, **kwargs)
+        response.raise_for_status()
+        return response.json()
+
+    def list_nba_markets(self) -> List[Market]:
+        payload = self._request("GET", "/markets", params={"tag": "NBA"})
+        markets = []
+        for raw in payload.get("markets", []):
+            markets.append(
+                Market(
+                    id=raw["id"],
+                    question=raw.get("question", ""),
+                    status=raw.get("status", ""),
+                    outcome_yes=(raw.get("outcomePrices") or {}).get("yes"),
+                    outcome_no=(raw.get("outcomePrices") or {}).get("no"),
+                )
+            )
+        return markets
+
+    def fetch_orderbook(self, market_id: str) -> Orderbook:
+        payload = self._request("GET", f"/markets/{market_id}")
+        outcome_prices = payload.get("outcomePrices", {})
+        return Orderbook(
+            market_id=market_id,
+            yes_price=self._safe_float(outcome_prices.get("yes")),
+            no_price=self._safe_float(outcome_prices.get("no")),
+        )
+
+    @staticmethod
+    def _safe_float(value: Any) -> Optional[float]:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+
+__all__ = ["PolymarketClient", "Market", "Orderbook"]

--- a/nba_probs/tests/conftest.py
+++ b/nba_probs/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/nba_probs/tests/test_config.py
+++ b/nba_probs/tests/test_config.py
@@ -1,0 +1,31 @@
+import pytest
+
+pytest.importorskip("pydantic")
+pytest.importorskip("pydantic_settings")
+
+from nba_probs.config import Paths, get_settings
+
+
+def test_paths_ensure_exists(tmp_path):
+    paths = Paths(
+        project_root=tmp_path,
+        data_dir=tmp_path / "data",
+        raw_data_dir=tmp_path / "data" / "raw",
+        processed_data_dir=tmp_path / "data" / "processed",
+        models_dir=tmp_path / "data" / "models",
+        polymarket_dir=tmp_path / "data" / "polymarket",
+    )
+
+    paths.ensure_exists()
+
+    assert paths.data_dir.exists()
+    assert paths.raw_data_dir.exists()
+    assert paths.processed_data_dir.exists()
+    assert paths.models_dir.exists()
+    assert paths.polymarket_dir.exists()
+
+
+def test_get_settings_cached():
+    first = get_settings()
+    second = get_settings()
+    assert first is second

--- a/nba_probs/tests/test_data_pipeline.py
+++ b/nba_probs/tests/test_data_pipeline.py
@@ -1,0 +1,89 @@
+import pytest
+
+pd = pytest.importorskip("pandas")
+
+from nba_probs.data_pipeline import summarize_game_by_minute
+
+
+def _sample_play_by_play() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "gameId": "001",
+                "periodNumber": 1,
+                "clock": "PT11M59.00S",
+                "homeScore": 0,
+                "awayScore": 0,
+                "homeTeamId": 100,
+                "visitorTeamId": 200,
+                "gameDate": "2024-10-01",
+            },
+            {
+                "gameId": "001",
+                "periodNumber": 1,
+                "clock": "PT11M00.00S",
+                "homeScore": 3,
+                "awayScore": 0,
+                "homeTeamId": 100,
+                "visitorTeamId": 200,
+                "gameDate": "2024-10-01",
+            },
+            {
+                "gameId": "001",
+                "periodNumber": 1,
+                "clock": "PT10M45.00S",
+                "homeScore": 3,
+                "awayScore": 2,
+                "homeTeamId": 100,
+                "visitorTeamId": 200,
+                "gameDate": "2024-10-01",
+            },
+            {
+                "gameId": "001",
+                "periodNumber": 4,
+                "clock": "PT00M00.00S",
+                "homeScore": 102,
+                "awayScore": 95,
+                "homeTeamId": 100,
+                "visitorTeamId": 200,
+                "gameDate": "2024-10-01",
+            },
+        ]
+    )
+
+
+def test_summarize_game_by_minute_produces_expected_columns():
+    plays = _sample_play_by_play()
+    summary = summarize_game_by_minute(plays)
+
+    assert not summary.empty
+    assert {
+        "game_id",
+        "minute_index",
+        "period",
+        "seconds_remaining",
+        "home_team_score",
+        "away_team_score",
+        "home_team_id",
+        "away_team_id",
+        "home_win",
+        "score_margin",
+    } <= set(summary.columns)
+
+    assert summary["home_win"].iloc[0] == 1
+    assert summary["score_margin"].iloc[0] == summary["home_team_score"].iloc[0] - summary["away_team_score"].iloc[0]
+
+
+def test_summarize_game_by_minute_handles_empty_input():
+    empty = pd.DataFrame(columns=[
+        "gameId",
+        "periodNumber",
+        "clock",
+        "homeScore",
+        "awayScore",
+        "homeTeamId",
+        "visitorTeamId",
+    ])
+
+    with pytest.raises(ValueError):
+        summarize_game_by_minute(empty)

--- a/nba_probs/tests/test_modeling.py
+++ b/nba_probs/tests/test_modeling.py
@@ -1,0 +1,49 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+pd = pytest.importorskip("pandas")
+pytest.importorskip("sklearn")
+pytest.importorskip("joblib")
+
+from nba_probs.modeling import load_model, predict_win_probability, train_baseline_model
+from sklearn.linear_model import LogisticRegression
+
+
+def sample_training_data() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "score_margin": [-12, -8, -3, 0, 2, 5, 9, 11, 7, -5, 4, -2],
+            "seconds_remaining": [30, 120, 240, 360, 420, 480, 540, 600, 660, 720, 780, 840],
+            "home_win": [0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 1, 0],
+        }
+    )
+
+
+def test_train_baseline_model_returns_metrics(tmp_path):
+    data = sample_training_data()
+    artifacts = train_baseline_model(data, random_state=0)
+
+    assert isinstance(artifacts.model, LogisticRegression)
+    assert artifacts.train_rows > 0
+    assert 0 <= artifacts.brier <= 1
+    assert 0 <= artifacts.roc_auc <= 1
+
+    model_path = tmp_path / "model.joblib"
+    artifacts.save(model_path)
+
+    loaded = load_model(model_path)
+    assert np.isclose(loaded.brier, artifacts.brier)
+    assert np.isclose(loaded.roc_auc, artifacts.roc_auc)
+
+
+def test_predict_win_probability_in_range():
+    data = sample_training_data()
+    artifacts = train_baseline_model(data, random_state=0)
+
+    prob = predict_win_probability(
+        artifacts.model,
+        score_margin=5,
+        seconds_remaining=300,
+    )
+
+    assert 0.0 <= prob <= 1.0

--- a/nba_probs/tests/test_polymarket.py
+++ b/nba_probs/tests/test_polymarket.py
@@ -1,0 +1,17 @@
+import pytest
+
+pytest.importorskip("requests")
+
+from nba_probs.polymarket import Orderbook, PolymarketClient
+
+
+def test_orderbook_implied_probabilities():
+    orderbook = Orderbook(market_id="abc", yes_price=0.62, no_price=0.4)
+    assert orderbook.implied_yes_probability == 0.62
+    assert orderbook.implied_no_probability == 0.4
+
+
+def test_safe_float_handles_invalid_values():
+    assert PolymarketClient._safe_float(None) is None
+    assert PolymarketClient._safe_float("not-a-number") is None
+    assert PolymarketClient._safe_float("0.55") == 0.55


### PR DESCRIPTION
## Summary
- add an `nba_probs` subproject with documentation, gitignore rules, and project configuration
- scaffold Python package modules for configuration management, data processing, modeling, and Polymarket integration
- provide CLI utilities for downloading minute-level game summaries and capturing Polymarket snapshots

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db24dbe7688320843da113128b0a80