### PR TITLE
Add prototype Polymarket market maker bots

### DIFF
--- a/marketmaker/.env.example
+++ b/marketmaker/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env and populate with your Polymarket credentials.
+POLYMARKET_API_KEY=
+POLYMARKET_WALLET_ADDRESS=
+POLYMARKET_PRIVATE_KEY=

--- a/marketmaker/README.md
+++ b/marketmaker/README.md
@@ -1,0 +1,61 @@
+# Market Maker Bot Prototypes
+
+This directory contains two experimental versions of a minimal Polymarket market-making bot. Both variants share the same core trading idea:
+
+* Pull the most recent quote for each configured market.
+* Place a bid $0.02 below and an ask $0.02 above the most recent price.
+* Refresh this quoting logic every five seconds.
+
+> **Warning**
+> These bots are examples only. They do not handle production concerns such as balance checks, error recovery, regulatory obligations, or full authentication flows. Use them at your own risk and always test with small amounts first.
+
+## Layout
+
+```
+marketmaker/
+├── README.md              – This file.
+├── config.py              – Shared configuration helpers.
+├── client.py              – Minimal Polymarket REST client wrapper.
+├── basic_bot.py           – Blocking implementation.
+└── async_bot.py           – AsyncIO-based implementation.
+```
+
+## Requirements
+
+* Python 3.11+
+* `requests`, `python-dotenv`, and (for the async version) `aiohttp`
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Copy the sample environment file and fill in your credentials:
+
+```bash
+cp .env.example .env
+```
+
+## Running the Bots
+
+### Blocking Version
+
+```bash
+python basic_bot.py --markets MARKET_ID1 MARKET_ID2
+```
+
+### Async Version
+
+```bash
+python async_bot.py --markets MARKET_ID1 MARKET_ID2
+```
+
+Both scripts accept the following options:
+
+* `--markets`: One or more Polymarket market IDs to quote.
+* `--spread`: Half-spread (default 0.02) added/subtracted from the mid price when quoting.
+* `--interval`: Seconds between quote refresh cycles (default 5 seconds).
+* `--size`: Quantity per order (default 10 shares).
+
+Review each file for additional customisation hooks.

--- a/marketmaker/async_bot.py
+++ b/marketmaker/async_bot.py
@@ -1,0 +1,116 @@
+"""AsyncIO implementation of the Polymarket market maker bot."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+import time
+from typing import Sequence
+
+from client import AsyncPolymarketClient
+from config import build_arg_parser, load_settings, parse_markets
+
+LOG = logging.getLogger("marketmaker.async")
+
+
+def clip_price(price: float) -> float:
+    return max(0.01, min(0.99, round(price, 4)))
+
+
+async def refresh_market(
+    client: AsyncPolymarketClient,
+    market_id: str,
+    spread: float,
+    size: float,
+) -> None:
+    try:
+        quote = await client.latest_quote(market_id)
+        bid = clip_price(quote.price - spread)
+        ask = clip_price(quote.price + spread)
+        LOG.info("%s | mid=%.4f bid=%.4f ask=%.4f", market_id, quote.price, bid, ask)
+
+        await client.cancel_all_orders(market_id)
+        await client.create_order(
+            market_id=market_id,
+            outcome_id=quote.outcome_id,
+            side="buy",
+            price=bid,
+            size=size,
+        )
+        await client.create_order(
+            market_id=market_id,
+            outcome_id=quote.outcome_id,
+            side="sell",
+            price=ask,
+            size=size,
+        )
+    except Exception as exc:  # noqa: BLE001 - broad logging for demo simplicity
+        LOG.exception("Failed to refresh market %s: %s", market_id, exc)
+
+
+async def run_loop(
+    client: AsyncPolymarketClient,
+    markets: Sequence[str],
+    spread: float,
+    size: float,
+    interval: float,
+) -> None:
+    while True:
+        cycle_start = time.monotonic()
+        await asyncio.gather(
+            *(
+                refresh_market(
+                    client=client,
+                    market_id=market_id,
+                    spread=spread,
+                    size=size,
+                )
+                for market_id in markets
+            )
+        )
+        elapsed = time.monotonic() - cycle_start
+        sleep_for = max(0.0, interval - elapsed)
+        if sleep_for:
+            await asyncio.sleep(sleep_for)
+
+
+async def async_main(argv: Sequence[str] | None = None) -> int:
+    parser = build_arg_parser("Async market maker bot")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    try:
+        settings = load_settings()
+    except RuntimeError as exc:
+        LOG.error("%s", exc)
+        return 1
+
+    client = AsyncPolymarketClient(settings=settings)
+    markets = parse_markets(args.markets)
+    LOG.info("Starting async market maker for %d markets", len(markets))
+
+    try:
+        await run_loop(
+            client=client,
+            markets=markets,
+            spread=float(args.spread),
+            size=float(args.size),
+            interval=float(args.interval),
+        )
+    except KeyboardInterrupt:
+        LOG.info("Received interrupt, shutting down")
+    finally:
+        await client.close()
+    return 0
+
+
+def main() -> int:
+    return asyncio.run(async_main())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/marketmaker/basic_bot.py
+++ b/marketmaker/basic_bot.py
@@ -1,0 +1,91 @@
+"""Blocking (threaded) version of the Polymarket market maker bot."""
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from typing import Sequence
+
+from client import PolymarketClient
+from config import build_arg_parser, load_settings, parse_markets
+
+LOG = logging.getLogger("marketmaker.basic")
+
+
+def clip_price(price: float) -> float:
+    """Ensure the price stays within Polymarket's [0.01, 0.99] range."""
+
+    return max(0.01, min(0.99, round(price, 4)))
+
+
+def run_loop(client: PolymarketClient, markets: Sequence[str], spread: float, size: float, interval: float) -> None:
+    """Continuously refresh quotes for the configured markets."""
+
+    while True:
+        cycle_start = time.time()
+        for market_id in markets:
+            try:
+                quote = client.latest_quote(market_id)
+                bid = clip_price(quote.price - spread)
+                ask = clip_price(quote.price + spread)
+
+                LOG.info("%s | mid=%.4f bid=%.4f ask=%.4f", market_id, quote.price, bid, ask)
+
+                client.cancel_all_orders(market_id)
+                client.create_order(
+                    market_id=market_id,
+                    outcome_id=quote.outcome_id,
+                    side="buy",
+                    price=bid,
+                    size=size,
+                )
+                client.create_order(
+                    market_id=market_id,
+                    outcome_id=quote.outcome_id,
+                    side="sell",
+                    price=ask,
+                    size=size,
+                )
+            except Exception as exc:  # noqa: BLE001 - demo tool, log everything
+                LOG.exception("Failed to refresh market %s: %s", market_id, exc)
+
+        elapsed = time.time() - cycle_start
+        sleep_for = max(0.0, interval - elapsed)
+        if sleep_for:
+            time.sleep(sleep_for)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_arg_parser("Blocking market maker bot")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    try:
+        settings = load_settings()
+    except RuntimeError as exc:
+        LOG.error("%s", exc)
+        return 1
+
+    client = PolymarketClient(settings=settings)
+    markets = parse_markets(args.markets)
+    LOG.info("Starting blocking market maker for %d markets", len(markets))
+
+    try:
+        run_loop(
+            client=client,
+            markets=markets,
+            spread=float(args.spread),
+            size=float(args.size),
+            interval=float(args.interval),
+        )
+    except KeyboardInterrupt:
+        LOG.info("Received interrupt, shutting down")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/marketmaker/client.py
+++ b/marketmaker/client.py
@@ -1,0 +1,197 @@
+"""Very small Polymarket REST client used by both bot variants."""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+
+from config import Settings
+
+try:  # pragma: no cover - optional dependency guard
+    import aiohttp
+except ImportError:  # pragma: no cover - optional dependency guard
+    aiohttp = None
+
+LOG = logging.getLogger(__name__)
+
+
+@dataclass
+class Quote:
+    """Represents the most recent market quote used for pricing."""
+
+    market_id: str
+    outcome_id: str
+    price: float
+    timestamp: float
+
+
+class PolymarketClient:
+    """Tiny helper around the Polymarket public and trading APIs.
+
+    The real trading API requires a signature that is outside the scope of this
+    example. For demonstration purposes we only attach the API key header and
+    assume the `private_key` has been used elsewhere to sign requests if
+    necessary.
+    """
+
+    PUBLIC_BASE_URL = "https://gamma-api.polymarket.com"
+    TRADING_BASE_URL = "https://trading-api.polymarket.com"
+
+    def __init__(self, settings: Settings, session: Optional[requests.Session] = None) -> None:
+        self._settings = settings
+        self._session = session or requests.Session()
+        self._session.headers.update({"X-API-Key": settings.api_key})
+
+    # ------------------------------------------------------------------
+    # Public market data
+    # ------------------------------------------------------------------
+    def fetch_market(self, market_id: str) -> Dict[str, Any]:
+        """Return the raw market payload from the public API."""
+
+        url = f"{self.PUBLIC_BASE_URL}/markets/{market_id}"
+        response = self._session.get(url, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def latest_quote(self, market_id: str) -> Quote:
+        """Extract a simplified quote structure for the given market."""
+
+        market = self.fetch_market(market_id)
+        try:
+            outcome = market["outcomes"][0]
+            price = float(outcome.get("price", outcome.get("lastPrice")))
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            raise RuntimeError(f"Unable to parse quote for market {market_id}") from exc
+
+        return Quote(
+            market_id=market_id,
+            outcome_id=outcome.get("id", ""),
+            price=price,
+            timestamp=time.time(),
+        )
+
+    # ------------------------------------------------------------------
+    # Trading endpoints (simplified)
+    # ------------------------------------------------------------------
+    def create_order(
+        self,
+        market_id: str,
+        outcome_id: str,
+        side: str,
+        price: float,
+        size: float,
+    ) -> Dict[str, Any]:
+        """Submit an order to the trading API.
+
+        The payload fields are indicative; consult the official Polymarket
+        documentation for the exact schema required by the live API.
+        """
+
+        payload = {
+            "marketId": market_id,
+            "outcomeId": outcome_id,
+            "side": side,
+            "price": price,
+            "size": size,
+            "walletAddress": self._settings.wallet_address,
+        }
+        url = f"{self.TRADING_BASE_URL}/orders"
+        response = self._session.post(url, json=payload, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def cancel_all_orders(self, market_id: str) -> Dict[str, Any]:
+        """Cancel every open order for the configured wallet in a market."""
+
+        url = f"{self.TRADING_BASE_URL}/orders/cancel"
+        payload = {
+            "marketId": market_id,
+            "walletAddress": self._settings.wallet_address,
+        }
+        response = self._session.post(url, json=payload, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+
+class AsyncPolymarketClient:
+    """Asynchronous flavour of :class:`PolymarketClient`."""
+
+    PUBLIC_BASE_URL = PolymarketClient.PUBLIC_BASE_URL
+    TRADING_BASE_URL = PolymarketClient.TRADING_BASE_URL
+
+    def __init__(self, settings: Settings, session: Optional[aiohttp.ClientSession] = None) -> None:
+        if aiohttp is None:  # pragma: no cover - runtime guard
+            raise RuntimeError("aiohttp is not installed; install requirements.txt first")
+
+        self._settings = settings
+        self._session = session
+
+    async def _session_ctx(self) -> aiohttp.ClientSession:
+        if self._session is None:
+            self._session = aiohttp.ClientSession(
+                headers={"X-API-Key": self._settings.api_key}
+            )
+        return self._session
+
+    async def close(self) -> None:
+        if self._session:
+            await self._session.close()
+
+    # ------------------------------------------------------------------
+    async def fetch_market(self, market_id: str) -> Dict[str, Any]:
+        session = await self._session_ctx()
+        url = f"{self.PUBLIC_BASE_URL}/markets/{market_id}"
+        async with session.get(url, timeout=10) as response:
+            response.raise_for_status()
+            return await response.json()
+
+    async def latest_quote(self, market_id: str) -> Quote:
+        market = await self.fetch_market(market_id)
+        try:
+            outcome = market["outcomes"][0]
+            price = float(outcome.get("price", outcome.get("lastPrice")))
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            raise RuntimeError(f"Unable to parse quote for market {market_id}") from exc
+
+        return Quote(
+            market_id=market_id,
+            outcome_id=outcome.get("id", ""),
+            price=price,
+            timestamp=time.time(),
+        )
+
+    async def create_order(
+        self,
+        market_id: str,
+        outcome_id: str,
+        side: str,
+        price: float,
+        size: float,
+    ) -> Dict[str, Any]:
+        session = await self._session_ctx()
+        url = f"{self.TRADING_BASE_URL}/orders"
+        payload = {
+            "marketId": market_id,
+            "outcomeId": outcome_id,
+            "side": side,
+            "price": price,
+            "size": size,
+            "walletAddress": self._settings.wallet_address,
+        }
+        async with session.post(url, json=payload, timeout=10) as response:
+            response.raise_for_status()
+            return await response.json()
+
+    async def cancel_all_orders(self, market_id: str) -> Dict[str, Any]:
+        session = await self._session_ctx()
+        url = f"{self.TRADING_BASE_URL}/orders/cancel"
+        payload = {
+            "marketId": market_id,
+            "walletAddress": self._settings.wallet_address,
+        }
+        async with session.post(url, json=payload, timeout=10) as response:
+            response.raise_for_status()
+            return await response.json()

--- a/marketmaker/config.py
+++ b/marketmaker/config.py
@@ -1,0 +1,81 @@
+"""Configuration helpers shared by the market maker prototypes."""
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from dotenv import load_dotenv
+
+
+@dataclass
+class Settings:
+    """Runtime configuration for interacting with the Polymarket API."""
+
+    api_key: str
+    wallet_address: str
+    private_key: str
+
+
+def load_settings() -> Settings:
+    """Load settings from environment variables (.env supported)."""
+
+    load_dotenv()
+
+    api_key = os.getenv("POLYMARKET_API_KEY", "")
+    wallet_address = os.getenv("POLYMARKET_WALLET_ADDRESS", "")
+    private_key = os.getenv("POLYMARKET_PRIVATE_KEY", "")
+
+    missing = [
+        name
+        for name, value in {
+            "POLYMARKET_API_KEY": api_key,
+            "POLYMARKET_WALLET_ADDRESS": wallet_address,
+            "POLYMARKET_PRIVATE_KEY": private_key,
+        }.items()
+        if not value
+    ]
+    if missing:
+        raise RuntimeError(
+            "Missing Polymarket credentials: " + ", ".join(missing)
+        )
+
+    return Settings(api_key=api_key, wallet_address=wallet_address, private_key=private_key)
+
+
+def build_arg_parser(description: str) -> argparse.ArgumentParser:
+    """Construct the common CLI argument parser."""
+
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "--markets",
+        nargs="+",
+        required=True,
+        help="One or more Polymarket market IDs to make markets on.",
+    )
+    parser.add_argument(
+        "--spread",
+        type=float,
+        default=0.02,
+        help="Half-spread to quote around the latest price (default: 0.02)",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=5.0,
+        help="Seconds to wait between refresh cycles (default: 5)",
+    )
+    parser.add_argument(
+        "--size",
+        type=float,
+        default=10.0,
+        help="Per-order size in shares (default: 10)",
+    )
+    return parser
+
+
+def parse_markets(raw_markets: Iterable[str]) -> List[str]:
+    """Normalise a user-provided iterable of market identifiers."""
+
+    return [market.strip() for market in raw_markets if market.strip()]

--- a/marketmaker/requirements.txt
+++ b/marketmaker/requirements.txt
@@ -1,0 +1,3 @@
+aiohttp>=3.9.0
+python-dotenv>=1.0.0
+requests>=2.31.0


### PR DESCRIPTION
## Summary
- add a new `marketmaker` brand with blocking and asyncio bot prototypes for Polymarket
- include shared configuration helpers, REST clients, and sample environment/requirements files

## Testing
- python -m compileall marketmaker

------
https://chatgpt.com/codex/tasks/task_e_68e53f09430083208a701608f570ada6