### PR TITLE
Add demo mode to Polymarket Baby script

### DIFF
--- a/polymarket_baby/README.md
+++ b/polymarket_baby/README.md
@@ -1,0 +1,82 @@
+# Polymarket Baby
+
+Polymarket Baby is a minimal Python script that polls the public [Polymarket](https://polymarket.com) API every five minutes and prints information about the most recent trade. It is intended as a simple example of working with the Polymarket REST interface.
+
+## Requirements
+
+* Python 3.11 or later (any modern Python 3 should work)
+* `requests` for making HTTP calls
+
+## Setup
+
+1. Clone the repository and change into the project directory:
+
+   ```bash
+   git clone <your-fork-url>
+   cd polymarket_baby
+   ```
+
+2. Create a virtual environment (optional but recommended) and install dependencies:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt  # optional helper if you export from pyproject
+   ```
+
+   or install directly from the `pyproject.toml` definition:
+
+   ```bash
+   pip install .
+   ```
+
+   The only required dependency is `requests`.
+
+## Running the script
+
+Execute the script with Python:
+
+```bash
+python main.py
+```
+
+By default the program runs in **demo mode**, which prints formatted sample
+trades without contacting Polymarket. This avoids failures when running in
+restricted environments (such as sandboxes that cannot reach the public API)
+while still showcasing the output format.
+
+To connect to Polymarket for real, pass the `--live` flag:
+
+```bash
+python main.py --live
+```
+
+The live mode will:
+
+1. Fetch the most recent trade from `https://api.polymarket.com` every five minutes.
+2. Print the market question, the outcome selected, and the USD amount for the trade.
+3. Continue running until you stop it with `Ctrl+C`.
+
+### Expected output
+
+Demo output will look similar to:
+
+```
+[2024-04-29 12:30:00] Market: Who will win the 2024 US Presidential Election? | Outcome: YES on Candidate A | Amount: $23.45
+```
+
+When running in live mode, actual values depend on real-time Polymarket
+activity. If the script cannot reach the API it will log an error and retry
+after five minutes.
+
+## Notes
+
+* The script uses `time.sleep(300)` to pause between requests as requested.
+* Network access to `https://api.polymarket.com` must be available; otherwise the script will raise an error while trying to fetch the latest trade.
+* Use `Ctrl+C` to stop the script gracefully.
+
+## Troubleshooting
+
+* **Proxy or firewall issues** – If you are behind a proxy, ensure the appropriate proxy environment variables are configured so `requests` can connect to the Polymarket API.
+* **SSL errors** – Make sure your Python installation trusts the CA certificates required by the Polymarket endpoint.
+

--- a/polymarket_baby/main.py
+++ b/polymarket_baby/main.py
@@ -1,0 +1,203 @@
+"""Entrypoint script for the Polymarket Baby project.
+
+This module exposes helpers for polling the public Polymarket API and
+formatting trade payloads. A small command-line interface is included: it
+defaults to a network-free demo mode but can poll the real API when invoked
+with the ``--live`` flag.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import itertools
+import sys
+import time
+from typing import Any, Dict, Iterable, Optional, Sequence
+
+import requests
+
+# Base endpoint serving recent trades. The API supports pagination via
+# query parameters such as ``limit``. We request a single trade because we
+# only care about the latest event.
+API_URL = "https://api.polymarket.com/trades"
+
+# Number of seconds to wait between API calls (5 minutes).
+POLL_INTERVAL_SECONDS = 300
+
+# Sample trades used when the script runs in "demo" mode. They provide a quick
+# way to preview the output format without making any network requests—useful
+# in restricted environments such as automated tests or sandboxes that cannot
+# reach Polymarket's servers.
+SAMPLE_TRADES = (
+    {
+        "market": "Will Bitcoin close above $75k on 2024-12-31?",
+        "outcome": "Yes",
+        "cost": 42.50,
+    },
+    {
+        "market": {
+            "question": "Who will win the 2024 US Presidential Election?",
+        },
+        "outcome": {"name": "Candidate A"},
+        "amount": "18.25",
+    },
+    {
+        "title": "Will a commercial mission land on the Moon this year?",
+        "side": "NO",
+        "value": 7.75,
+    },
+)
+
+
+def _extract_first(iterable: Iterable[Any]) -> Optional[Any]:
+    """Return the first element of an iterable or ``None`` if it is empty."""
+
+    for item in iterable:
+        return item
+    return None
+
+
+def _coerce_trades(payload: Any) -> Iterable[Dict[str, Any]]:
+    """Normalize the JSON payload into an iterable of trade dictionaries.
+
+    The Polymarket API has returned both bare lists and objects with a
+    ``data`` field in the past. To keep the script resilient, we look for
+    several common patterns and fall back to an empty list if we cannot
+    recognize the structure.
+    """
+
+    if isinstance(payload, list):
+        return payload
+
+    if isinstance(payload, dict):
+        for key in ("data", "trades", "results"):
+            maybe = payload.get(key)
+            if isinstance(maybe, list):
+                return maybe
+
+    return []
+
+
+def _safe_get(trade: Dict[str, Any], *keys: str) -> Optional[Any]:
+    """Attempt to retrieve the first non-empty value associated with keys."""
+
+    for key in keys:
+        value = trade.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def format_trade(trade: Dict[str, Any]) -> str:
+    """Convert a raw trade dictionary into a human-readable string."""
+
+    market = _safe_get(trade, "market", "question", "title")
+    if isinstance(market, dict):
+        market_question = _safe_get(market, "question", "title", "name") or "Unknown market"
+    else:
+        market_question = str(market) if market is not None else "Unknown market"
+
+    outcome = _safe_get(trade, "outcome", "side", "token")
+    if isinstance(outcome, dict):
+        outcome_text = _safe_get(outcome, "name", "label", "title") or "Unknown outcome"
+    else:
+        outcome_text = str(outcome) if outcome is not None else "Unknown outcome"
+
+    amount_usd = _safe_get(trade, "cost", "amount", "value", "priceUsd")
+    try:
+        amount_number = float(amount_usd) if amount_usd is not None else 0.0
+    except (TypeError, ValueError):
+        amount_number = 0.0
+
+    timestamp = dt.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+    return (
+        f"[{timestamp}] Market: {market_question} | "
+        f"Outcome: {outcome_text} | Amount: ${amount_number:,.2f}"
+    )
+
+
+def fetch_latest_trade() -> Optional[Dict[str, Any]]:
+    """Fetch the most recent trade from Polymarket.
+
+    Returns a dictionary representing the trade, or ``None`` when no trade
+    data is returned by the API.
+    """
+
+    response = requests.get(API_URL, params={"limit": 1}, timeout=30)
+    response.raise_for_status()
+    payload = response.json()
+    trades = _coerce_trades(payload)
+    return _extract_first(trades)
+
+
+def run_live_loop() -> None:
+    """Continuously poll Polymarket and print information about trades."""
+
+    print("Starting Polymarket Baby trade watcher. Press Ctrl+C to stop.")
+    while True:
+        try:
+            trade = fetch_latest_trade()
+        except requests.RequestException as exc:
+            # Network problems are expected from time to time. We log the
+            # issue and continue looping so the script remains resilient.
+            print(f"Error fetching trades: {exc}", file=sys.stderr)
+        else:
+            if trade is None:
+                print("No trades returned by the API.")
+            else:
+                print(format_trade(trade))
+
+        # Wait for the requested polling interval before fetching again.
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+def run_demo_loop(iterations: int = 3, sleep_seconds: int = 1) -> None:
+    """Emit formatted sample trades without contacting the Polymarket API."""
+
+    print(
+        "Running in demo mode. Use --live to poll Polymarket. "
+        "Press Ctrl+C to stop."
+    )
+    for idx, trade in zip(range(iterations), itertools.cycle(SAMPLE_TRADES)):
+        # ``format_trade`` already handles dictionaries and strings in the same
+        # way the live API would deliver them, so we can re-use it for the demo
+        # data.
+        print(format_trade(trade))
+        if idx < iterations - 1:
+            time.sleep(sleep_seconds)
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    """Return parsed command-line arguments for the script."""
+
+    parser = argparse.ArgumentParser(description="Poll the Polymarket API")
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help=(
+            "Fetch real trades from Polymarket. Without this flag the script "
+            "prints sample output only, which is safer in restricted "
+            "environments."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    """Entrypoint handling command-line arguments for the script."""
+
+    args = parse_args(argv)
+    if args.live:
+        run_live_loop()
+    else:
+        run_demo_loop()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        # Provide a friendly shutdown message when the user stops the script.
+        print("\nStopping Polymarket Baby. Goodbye!")
+

--- a/polymarket_baby/pyproject.toml
+++ b/polymarket_baby/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "polymarket-baby"
+version = "0.1.0"
+description = "Minimal Polymarket trade poller example"
+readme = "README.md"
+authors = [
+  { name = "Your Name", email = "you@example.com" }
+]
+requires-python = ">=3.11"
+dependencies = [
+  "requests>=2.31.0"
+]
+
+[project.urls]
+Homepage = "https://github.com/your-account/polymarket_baby"
+


### PR DESCRIPTION
## Summary
- add an offline demo mode to the Polymarket Baby CLI so it no longer depends on external network access by default
- keep the existing live polling loop behind a --live flag while preserving the helper utilities
- document the new demo and live modes in the project README

## Testing
- python polymarket_baby/main.py

------
https://chatgpt.com/codex/tasks/task_e_68f91ece684c83209f7ee3a8c2508ab4