### PR TITLE
Fix iPhone caching: add cache-busting to CSS/JS links

### DIFF
--- a/livy-race-game/index.html
+++ b/livy-race-game/index.html
@@ -6,7 +6,7 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <title>Livy's Race Game! 🏆</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles.css?v=2">
 </head>
 <body>
 <div id="app">
@@ -111,6 +111,6 @@
   </div>
 
 </div>
-<script src="script.js"></script>
+<script src="script.js?v=2"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds `?v=2` to the `styles.css` and `script.js` links in `index.html` so Safari on iPhone is forced to download the latest files instead of serving the old cached versions.

https://claude.ai/code/session_017cCUouyzhLt9aBHguJcDsw

---
_Generated by [Claude Code](https://claude.ai/code/session_017cCUouyzhLt9aBHguJcDsw)_